### PR TITLE
Bugfix - Added support for use of zenity --directory option when calling psidialogs.ask_folder()

### DIFF
--- a/psidialogs/plugins/zenity_wrapper.py
+++ b/psidialogs/plugins/zenity_wrapper.py
@@ -72,7 +72,7 @@ class Backend(IPlugin):
     def ask_string(self, args):
         return self._entry(args, pw=0)
         
-    def _file(self, args, multi):
+    def _file(self, args, multi, folder):
         options = {}
         separator = '|'
         options["--file-selection" ] = None
@@ -89,7 +89,7 @@ class Backend(IPlugin):
             result = result.split(separator)
         return result
         
-    def _choice(self, args, multi, folder):
+    def _choice(self, args, multi):
         options = {}
         separator = '|'
         options["--list" ] = None

--- a/psidialogs/plugins/zenity_wrapper.py
+++ b/psidialogs/plugins/zenity_wrapper.py
@@ -80,6 +80,8 @@ class Backend(IPlugin):
         if multi:
             options["--multiple" ] = None
             options["--separator" ] = separator
+        if folder:
+            options["--directory"] = None
         if args.default:
             options["--filename" ] = args.default 
         result = self._call(args, options)
@@ -87,7 +89,7 @@ class Backend(IPlugin):
             result = result.split(separator)
         return result
         
-    def _choice(self, args, multi):
+    def _choice(self, args, multi, folder):
         options = {}
         separator = '|'
         options["--list" ] = None
@@ -109,8 +111,12 @@ class Backend(IPlugin):
         
 
     def ask_file(self, args):
-        return self._file(args, multi=0)
-    
+        return self._file(args, multi=0, folder=0)
+
+    def ask_folder(self, args):
+        return self._file(args, multi=0, folder=1)
+
+
     def _ask_question(self, args, ok, cancel):
         options = {}
         options["--question" ] = None


### PR DESCRIPTION
When using zenity plugin, ask_folder() prompts user for string input instead of folder selection dialog. 

Added this to _file
        if folder:
            options["--directory"] = None

Added new function

```
def ask_folder(self, args):
    return self._file(args, multi=0, folder=1)
```

Modified _file dependent function ask_file() to match

```
def ask_file(self, args):
    return self._file(args, multi=0, folder=0)
```

Tested on Ubuntu 12.04-1 on 32 Bit - base install
